### PR TITLE
aiaprep comparison notebook

### DIFF
--- a/gallery/compare_aiaprep/compare_ssw_sunpy.ipynb
+++ b/gallery/compare_aiaprep/compare_ssw_sunpy.ipynb
@@ -447,6 +447,13 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.8"
+  },
+  "sunpy-gallery": {
+   "author": "Andrew Leonard",
+   "date": "April 2015",
+   "link_name": "Comparison of SSW and SunPy aiapreps",
+   "published": false,
+   "section_name": "Advanced"
   }
  },
  "nbformat": 4,

--- a/gallery/compare_aiaprep/compare_ssw_sunpy.ipynb
+++ b/gallery/compare_aiaprep/compare_ssw_sunpy.ipynb
@@ -1,0 +1,454 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#Comparing SSWIDL's aia_prep.pro to SunPy's aiaprep()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Aim"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This document aims to provide a qualitative comparison between SSWIDL's aiaprep.pro, and SunPy's `aiaprep()`. The purpose is not to show which one is 'more right' - I leave that task for someone far better at maths than me - but simply to demonstrate how the results of the two implementations differ. I have also not tested any of the various different ways of using each version, only the default no-arguments calls."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this demonstration I will use an AIA image from 2014-01-11 as the original. The IDL-processed level 1.5 version of this image has been saved to a fits file already using IDL 8.2.3 and aiaprep.pro version 4.11. The SunPy-processed version is calculated here, with Python 2.7.8 and SunPy 0.5.4.\n",
+    "\n",
+    "AIA images can be fairly noisy around the edges of the image, which will cause some pixels in those areas to have very different values after the transformation. The values of all pixels further from the solar centre than 1.3 solar radii are therefore set to be constant to reduce the effect of this noise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Import statements. Nothing to see here.\n",
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sunpy\n",
+    "from sunpy.map import Map\n",
+    "from sunpy.instr.aia import aiaprep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Load original image\n",
+    "origim = Map(\"aia171_2014-01-11T00_00.fits\")\n",
+    "# Trim the image to <= 1.3 solar radii.\n",
+    "# Apologies for the clunky implementation, I couldn't figure out how to do this using wcs.\n",
+    "lowx, highx = (origim.xrange[0] / origim.scale['x'],\n",
+    "               origim.xrange[1] / origim.scale['x'])\n",
+    "lowy, highy = (origim.yrange[0] / origim.scale['y'],\n",
+    "               origim.yrange[1] / origim.scale['y'])\n",
+    "x_grid, y_grid = np.mgrid[lowx:highx-1, lowy:highy-1]\n",
+    "r_grid = np.sqrt((x_grid ** 2.0) + (y_grid ** 2.0))\n",
+    "outer_rad = (origim.rsun_arcseconds * 1.3) / origim.scale['x']\n",
+    "origim.data[r_grid > outer_rad] = 1\n",
+    "\n",
+    "# Process original image with SunPy, and trim again\n",
+    "pypreppedim = aiaprep(origim)\n",
+    "lowx, highx = (pypreppedim.xrange[0] / pypreppedim.scale['x'],\n",
+    "               pypreppedim.xrange[1] / pypreppedim.scale['x'])\n",
+    "lowy, highy = (pypreppedim.yrange[0] / pypreppedim.scale['y'],\n",
+    "               pypreppedim.yrange[1] / pypreppedim.scale['y'])\n",
+    "x_grid, y_grid = np.mgrid[lowx:highx-1, lowy:highy-1]\n",
+    "r_grid = np.sqrt((x_grid ** 2.0) + (y_grid ** 2.0))\n",
+    "outer_rad = (pypreppedim.rsun_arcseconds * 1.3) / pypreppedim.scale['x']\n",
+    "pypreppedim.data[r_grid > outer_rad] = 1\n",
+    "\n",
+    "# Load image processed with IDL, and trim\n",
+    "idlpreppedim = Map(\"aia171_2014-01-11T00_00_idlprepped.fits\")\n",
+    "lowx, highx = (idlpreppedim.xrange[0] / idlpreppedim.scale['x'],\n",
+    "               idlpreppedim.xrange[1] / idlpreppedim.scale['x'])\n",
+    "lowy, highy = (idlpreppedim.yrange[0] / idlpreppedim.scale['y'],\n",
+    "               idlpreppedim.yrange[1] / idlpreppedim.scale['y'])\n",
+    "x_grid, y_grid = np.mgrid[lowx:highx-1, lowy:highy-1]\n",
+    "r_grid = np.sqrt((x_grid ** 2.0) + (y_grid ** 2.0))\n",
+    "outer_rad = (idlpreppedim.rsun_arcseconds * 1.3) / idlpreppedim.scale['x']\n",
+    "idlpreppedim.data[r_grid > outer_rad] = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can easily compare some of the relevant header information to check that it has been updated correctly by both versions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print 'Processing level'\n",
+    "print '  Original:', origim.processing_level\n",
+    "print '  SunPy:', pypreppedim.processing_level\n",
+    "print '  IDL:', idlpreppedim.processing_level, '\\n'\n",
+    "\n",
+    "print 'Pixel scale'\n",
+    "print '  Original:', origim.scale\n",
+    "print '  SunPy:', pypreppedim.scale\n",
+    "print '  IDL:', idlpreppedim.scale, '\\n'\n",
+    "\n",
+    "print 'Solar centre coordinates'\n",
+    "print '  Original:', origim.center\n",
+    "print '  SunPy:', pypreppedim.center\n",
+    "print '  IDL:', idlpreppedim.center, '\\n'\n",
+    "\n",
+    "print 'Solar centre pixel position'\n",
+    "print '  Original:', origim.reference_pixel\n",
+    "print '  SunPy:', pypreppedim.reference_pixel\n",
+    "print '  IDL:', idlpreppedim.reference_pixel, '\\n'\n",
+    "\n",
+    "print 'Rotation matrix'\n",
+    "print '  Original:\\n', origim.rotation_matrix\n",
+    "print '  SunPy:\\n', pypreppedim.rotation_matrix\n",
+    "print '  IDL:\\n', idlpreppedim.rotation_matrix, '\\n'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice in the above output that the IDL aia_prep doesn't quite set the image scale to exactly 0.6 arcsec per pixel, although it's probably close enough. Similarly, SunPy's `aiaprep()` sets the diagonals of the rotation matrix not to exactly zero, but very close.\n",
+    "\n",
+    "##Comparing SunPy to the original\n",
+    "Let's compare the SunPy-processed image to the original. We should expect the images to be very similar, since the pointing and rotation of AIA are usually only off by a little."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Visually compare original image to image processed using SunPy\"\"\"\n",
+    "\n",
+    "fig = plt.figure(figsize=(15, 8))\n",
+    "\n",
+    "fig.add_subplot(1, 2, 1)\n",
+    "origim.plot()\n",
+    "plt.title('Max: {:.2f}, Mean: {:.2f}, Min: {:.2f}'.format(origim.max(), origim.mean(), origim.min()))\n",
+    "plt.colorbar(orientation='horizontal')\n",
+    "\n",
+    "fig.add_subplot(1, 2, 2)\n",
+    "pypreppedim.plot()\n",
+    "plt.title('Max: {:.2f}, Mean: {:.2f}, Min: {:.2f}'.format(pypreppedim.max(), pypreppedim.mean(), pypreppedim.min()))\n",
+    "plt.colorbar(orientation='horizontal')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The images are indeed very nearly the same, so nothing has gone wildly wrong.\n",
+    "\n",
+    "Now let's look at the actual difference between the two images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Assess difference of SunPy image from original.\"\"\"\n",
+    "\n",
+    "diffim1 = Map(pypreppedim.data.copy(), pypreppedim.meta.copy())\n",
+    "# Calculate percentage difference \n",
+    "diffim1.data = ((origim.data - pypreppedim.data) / origim.data) * 100\n",
+    "\n",
+    "# Check some numbers\n",
+    "meandiff = diffim1.data[np.isfinite(diffim1.data)].mean()\n",
+    "stddiff = diffim1.data[np.isfinite(diffim1.data)].std()\n",
+    "maxdiff = diffim1.data[np.isfinite(diffim1.data)].max()\n",
+    "mindiff = diffim1.data[np.isfinite(diffim1.data)].min()\n",
+    "print 'Percentage difference:'\n",
+    "print 'Min: {:.5} %'.format(mindiff)\n",
+    "print 'Max: {:.5} %'.format(maxdiff)\n",
+    "print 'Mean: {:.4} %'.format(meandiff)\n",
+    "print 'Std Dev: {:.4} %'.format(stddiff)\n",
+    "print 'Discounted pixels: {}'.format(diffim1.size - np.count_nonzero(np.isfinite(diffim1.data)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Display difference\"\"\"\n",
+    "\n",
+    "# Plot difference Map\n",
+    "fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(15, 8))\n",
+    "plt.sca(ax[0])\n",
+    "diffim1.plot(cmap='coolwarm', vmin=-250, vmax=250)\n",
+    "plt.title('% difference map')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "# Plot histogram of differences\n",
+    "plt.sca(ax[1])\n",
+    "plt.hist(diffim1.data.flatten(), range=(-250, 250), bins=100, cumulative=True)\n",
+    "plt.axhline(diffim1.size, linestyle='--', color='black')\n",
+    "plt.axvline(0, linestyle='--', color='green')\n",
+    "plt.title('Individual pixel differences')\n",
+    "plt.xlabel('% difference')\n",
+    "plt.ylabel('Pixel count')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The difference image on the left shows that the processed image is very similar to the original, and differs most in areas where there are small-scale features or noise.\n",
+    "\n",
+    "The cumulative histogram on the right shows that most pixels vary very little from their original values after applying `aiaprep()`. The horizontal dashed line indicates the total number of pixels in the image, and the vertical line denotes zero difference from the original.\n",
+    "\n",
+    "Note that some pixels have been discounted, since a zero in the original image will result in an infinite difference value."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Comparing IDL to the original"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's do the same again for IDL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Visually compare original image to image processed using IDL\"\"\"\n",
+    "\n",
+    "fig = plt.figure(figsize=(15, 8))\n",
+    "\n",
+    "fig.add_subplot(1, 2, 1)\n",
+    "origim.plot()\n",
+    "plt.title('Max: {:.2f}, Mean: {:.2f}, Min: {:.2f}'.format(origim.max(), origim.mean(), origim.min()))\n",
+    "plt.colorbar(orientation='horizontal')\n",
+    "\n",
+    "fig.add_subplot(1, 2, 2)\n",
+    "idlpreppedim.plot()\n",
+    "plt.title('Max: {:.2f}, Mean: {:.2f}, Min: {:.2f}'.format(idlpreppedim.max(), idlpreppedim.mean(), idlpreppedim.min()))\n",
+    "plt.colorbar(orientation='horizontal')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, the processed image is very similar to the original image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Assess difference of IDL image from original.\"\"\"\n",
+    "\n",
+    "diffim2 = Map(idlpreppedim.data.copy(), idlpreppedim.meta.copy())\n",
+    "# Calculate percentage difference \n",
+    "diffim2.data = ((origim.data - idlpreppedim.data) / origim.data) * 100\n",
+    "\n",
+    "# Check some numbers\n",
+    "meandiff = diffim2.data[np.isfinite(diffim2.data)].mean()\n",
+    "stddiff = diffim2.data[np.isfinite(diffim2.data)].std()\n",
+    "maxdiff = diffim2.data[np.isfinite(diffim2.data)].max()\n",
+    "mindiff = diffim2.data[np.isfinite(diffim2.data)].min()\n",
+    "print 'Percentage difference:'\n",
+    "print 'Min: {:.5} %'.format(mindiff)\n",
+    "print 'Max: {:.5} %'.format(maxdiff)\n",
+    "print 'Mean: {:.4} %'.format(meandiff)\n",
+    "print 'Std Dev: {:.4} %'.format(stddiff)\n",
+    "print 'Discounted pixels: {}'.format(diffim2.size - np.count_nonzero(np.isfinite(diffim2.data)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Display difference\"\"\"\n",
+    "\n",
+    "# Plot difference Map\n",
+    "fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(15, 8))\n",
+    "plt.sca(ax[0])\n",
+    "diffim2.plot(cmap='coolwarm', vmin=-250, vmax=250)\n",
+    "plt.title('% difference map')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "# Plot histogram of differences\n",
+    "plt.sca(ax[1])\n",
+    "plt.hist(diffim2.data.flatten(), range=(-250, 250), bins=100, cumulative=True)\n",
+    "plt.axhline(diffim2.size, linestyle='--', color='black')\n",
+    "plt.axvline(0, linestyle='--', color='green')\n",
+    "plt.title('Individual pixel differences')\n",
+    "plt.xlabel('% difference')\n",
+    "plt.ylabel('Pixel count')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And again, most pixels show a very small change in value, with the greatest change where there are small-scale variations in the original image."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##Comparing SunPy to IDL\n",
+    "\n",
+    "Finally, perhaps the most important comparison is between the resultant images from both versions of the method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Assess difference of IDL image from original.\"\"\"\n",
+    "\n",
+    "diffim3 = Map(idlpreppedim.data.copy(), idlpreppedim.meta.copy())\n",
+    "# Calculate percentage difference \n",
+    "diffim3.data = ((idlpreppedim.data - pypreppedim.data) / idlpreppedim.data) * 100\n",
+    "\n",
+    "# Check some numbers\n",
+    "meandiff = diffim3.data[np.isfinite(diffim3.data)].mean()\n",
+    "stddiff = diffim3.data[np.isfinite(diffim3.data)].std()\n",
+    "maxdiff = diffim3.data[np.isfinite(diffim3.data)].max()\n",
+    "mindiff = diffim3.data[np.isfinite(diffim3.data)].min()\n",
+    "print 'Percentage difference:'\n",
+    "print 'Min: {:.5} %'.format(mindiff)\n",
+    "print 'Max: {:.5} %'.format(maxdiff)\n",
+    "print 'Mean: {:.4} %'.format(meandiff)\n",
+    "print 'Std Dev: {:.4} %'.format(stddiff)\n",
+    "print 'Discounted pixels: {}'.format(diffim3.size - np.count_nonzero(np.isfinite(diffim3.data)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Display difference\"\"\"\n",
+    "\n",
+    "# Plot difference Map\n",
+    "fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(15, 8))\n",
+    "plt.sca(ax[0])\n",
+    "diffim3.plot(cmap='coolwarm', vmin=-250, vmax=250)\n",
+    "plt.title('% difference map')\n",
+    "plt.colorbar()\n",
+    "\n",
+    "# Plot histogram of differences\n",
+    "plt.sca(ax[1])\n",
+    "plt.hist(diffim3.data.flatten(), range=(-250, 250), bins=100, cumulative=True)\n",
+    "plt.axhline(diffim3.size, linestyle='--', color='black')\n",
+    "plt.axvline(0, linestyle='--', color='green')\n",
+    "plt.title('Individual pixel differences')\n",
+    "plt.xlabel('% difference')\n",
+    "plt.ylabel('Pixel count')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see here that the processed images are more similar to each other than either is to the original. Some noisy areas still remain around the edges of the difference image. The solar disk, on the other hand, shows only very small differences between the output of the two methods. This suggests that IDL's aia_prep.pro and SunPy's `aiaprep()` can be used interchangeably without fear of any great difference in the results."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
IPython notebook comparing the old SSW aia_prep.pro to our new and shiny `aiaprep()`. Requires a few fits files to run correctly but I'm not sure how or where to include these currently.